### PR TITLE
Add contact form with theme and language toggles

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -1,7 +1,8 @@
-document.getElementById('site-footer').innerHTML = `
-<div class="container foot">
-  <div>© ${new Date().getFullYear()} Gonco Chicken • Moselweinstraße 14B, 56821 Ellenz-Poltersdorf</div>
-  <div class="muted">Allergene & Zusatzstoffe bitte im Laden erfragen.</div>
-  <a class="btn" href="#impressum">Impressum – Datenschutz</a>
-</div>
-`;
+function renderFooter(){
+  document.getElementById('site-footer').innerHTML = `
+  <div class="container foot">
+    <div>© ${new Date().getFullYear()} Gonco Chicken • Moselweinstraße 14B, 56821 Ellenz-Poltersdorf</div>
+    <div class="muted">${i18n[state.lang].footer.allergens}</div>
+    <a class="btn" href="#impressum">${i18n[state.lang].footer.impressum}</a>
+  </div>`;
+}

--- a/header.js
+++ b/header.js
@@ -1,13 +1,15 @@
-document.getElementById('site-header').innerHTML = `
-<div class="container nav">
-  <a class="brand" href="#home"><span class="logo"></span><span>Gonco Chicken</span></a>
-  <nav class="navlinks">
-    <span class="open-hours desktop">Täglich 11–21 Uhr</span>
-    <a class="btn" href="#menu">Menü</a>
-    <a class="btn" href="#about">Über uns</a>
-    <a class="btn" href="#contact">Kontakt</a>
-    <a class="btn primary" href="tel:+4926712411502">Anrufen</a>
-  </nav>
-  <button class="btn mobile" onclick="document.querySelector('.nav').classList.toggle('open')">☰</button>
-</div>
-`;
+function renderHeader(){
+  document.getElementById('site-header').innerHTML = `
+  <div class="container nav">
+    <a class="brand" href="#home"><span class="logo"></span><span>Gonco Chicken</span></a>
+    <nav class="navlinks">
+      <a class="btn" href="#menu">${i18n[state.lang].nav.menu}</a>
+      <a class="btn" href="#about">${i18n[state.lang].nav.about}</a>
+      <a class="btn" href="#contact">${i18n[state.lang].nav.contact}</a>
+      <a class="btn primary" href="tel:+4926712411502">${i18n[state.lang].nav.call}</a>
+      <button id="lang-toggle" class="btn">${state.lang === 'de' ? 'EN' : 'DE'}</button>
+      <button id="theme-toggle" class="btn">${state.theme === 'dark' ? '🌙' : '☀️'}</button>
+    </nav>
+    <button class="btn mobile" onclick="document.querySelector('.nav').classList.toggle('open')">☰</button>
+  </div>`;
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,123 @@
 <script src="pages/contact.js"></script>
 <script src="pages/impressum.js"></script>
 <script>
+const state = {
+  lang: localStorage.getItem('lang') || 'de',
+  theme: localStorage.getItem('theme') || 'dark'
+};
+
+const i18n = {
+  de: {
+    nav: { menu: 'Menü', about: 'Über uns', contact: 'Kontakt', call: 'Anrufen' },
+    footer: { allergens: 'Allergene & Zusatzstoffe bitte im Laden erfragen.', impressum: 'Impressum – Datenschutz' },
+    home: {
+      kicker: 'Ellenz-Poltersdorf • Mosel',
+      headline: 'Knuspriges Hähnchen, <br/>frisch & saftig – jeden Tag',
+      lead: 'Willkommen bei <strong>Gonco Chicken</strong>. Bei uns gibt’s gold-knuspriges Hähnchen, hausgemachte Saucen und Beilagen, die wirklich satt machen. Perfekt zum Mitnehmen oder zum Genießen vor Ort.',
+      btnMenu: 'Zum Menü',
+      btnAbout: 'Mehr über uns',
+      badgeHours: 'Täglich 11–21 Uhr',
+      badgeFresh: 'Frisch frittiert',
+      findUs: 'So findest du uns',
+      popup: 'Willkommen bei Gonco Chicken!'
+    },
+    menu: {
+      title: 'Menü',
+      items: [
+        { name: 'Classic Fried Chicken', desc: 'Knuspriges Hähnchen – 9,50 €' },
+        { name: 'Spicy Wings (8 Stk.)', desc: 'Feurig und knusprig – 8,90 €' },
+        { name: 'Chicken Burger', desc: 'Mit Salat & Sauce – 10,50 €' }
+      ]
+    },
+    about: {
+      title: 'Über uns',
+      lines: [
+        'Bei Gonco Chicken dreht sich alles um ehrliches Comfort Food.',
+        'Wir arbeiten mit regionalen Lieferanten zusammen.',
+        'Unsere Karte ist bewusst kompakt für beste Qualität.'
+      ]
+    },
+    contact: {
+      title: 'Kontakt',
+      info: 'Moselweinstraße 14B, 56821 Ellenz-Poltersdorf<br>Telefon: 02671 2411502<br>E-Mail: hello@goncochicken.de',
+      form: { name: 'Name', email: 'E-Mail', message: 'Nachricht', send: 'Senden' }
+    },
+    impressum: {
+      title: 'Impressum',
+      dataTitle: 'Datenschutzerklärung'
+    }
+  },
+  en: {
+    nav: { menu: 'Menu', about: 'About', contact: 'Contact', call: 'Call' },
+    footer: { allergens: 'Please ask in store for allergens & additives.', impressum: 'Imprint – Privacy' },
+    home: {
+      kicker: 'Ellenz-Poltersdorf • Mosel',
+      headline: 'Crispy chicken, <br/>fresh & juicy – every day',
+      lead: 'Welcome to <strong>Gonco Chicken</strong>. We serve golden crispy chicken, homemade sauces and sides that really fill you up. Perfect to take away or enjoy on site.',
+      btnMenu: 'View menu',
+      btnAbout: 'More about us',
+      badgeHours: 'Daily 11am–9pm',
+      badgeFresh: 'Freshly fried',
+      findUs: 'Find us',
+      popup: 'Welcome to Gonco Chicken!'
+    },
+    menu: {
+      title: 'Menu',
+      items: [
+        { name: 'Classic Fried Chicken', desc: 'Crispy chicken – €9.50' },
+        { name: 'Spicy Wings (8 pcs)', desc: 'Fiery and crispy – €8.90' },
+        { name: 'Chicken Burger', desc: 'With salad & sauce – €10.50' }
+      ]
+    },
+    about: {
+      title: 'About us',
+      lines: [
+        'At Gonco Chicken we focus on honest comfort food.',
+        'We work with local suppliers.',
+        'Our menu is intentionally compact for top quality.'
+      ]
+    },
+    contact: {
+      title: 'Contact',
+      info: 'Moselweinstraße 14B, 56821 Ellenz-Poltersdorf<br>Phone: +49 2671 2411502<br>Email: hello@goncochicken.de',
+      form: { name: 'Name', email: 'Email', message: 'Message', send: 'Send' }
+    },
+    impressum: {
+      title: 'Imprint',
+      dataTitle: 'Privacy Policy'
+    }
+  }
+};
+
+function applyTheme(){
+  document.body.classList.toggle('light', state.theme === 'light');
+  const btn = document.getElementById('theme-toggle');
+  if(btn) btn.textContent = state.theme === 'dark' ? '🌙' : '☀️';
+}
+
+function updateLang(){
+  document.documentElement.lang = state.lang;
+  const btn = document.getElementById('lang-toggle');
+  if(btn) btn.textContent = state.lang === 'de' ? 'EN' : 'DE';
+}
+
+function initToggles(){
+  document.getElementById('theme-toggle').addEventListener('click', () => {
+    state.theme = state.theme === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('theme', state.theme);
+    applyTheme();
+  });
+  document.getElementById('lang-toggle').addEventListener('click', () => {
+    state.lang = state.lang === 'de' ? 'en' : 'de';
+    localStorage.setItem('lang', state.lang);
+    renderHeader();
+    renderFooter();
+    updateLang();
+    initToggles();
+    router();
+  });
+}
+
 const routes = {
   '': renderHome,
   '#home': renderHome,
@@ -27,17 +144,24 @@ const routes = {
   '#contact': renderContact,
   '#impressum': renderImpressum
 };
+
 function router(){
   const hash = location.hash || '';
   document.getElementById('app').innerHTML = '';
   (routes[hash] || renderHome)();
 }
+
 window.addEventListener('hashchange', router);
 window.addEventListener('load', () => {
+  renderHeader();
+  renderFooter();
+  applyTheme();
+  updateLang();
+  initToggles();
   router();
   const popup = document.createElement('div');
   popup.className = 'popup';
-  popup.innerHTML = `<div class="popup-content"><p>Willkommen bei Gonco Chicken!</p><button class="btn close-popup">OK</button></div>`;
+  popup.innerHTML = `<div class="popup-content"><p>${i18n[state.lang].home.popup}</p><button class="btn close-popup">OK</button></div>`;
   document.body.appendChild(popup);
   setTimeout(() => popup.classList.add('show'), 500);
   popup.querySelector('.close-popup').addEventListener('click', () => popup.remove());

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,8 +1,7 @@
 function renderAbout(){
-document.getElementById('app').innerHTML = `
-<h2>Über uns</h2>
-<div class="card tile">Bei Gonco Chicken dreht sich alles um ehrliches Comfort Food.</div>
-<div class="card tile">Wir arbeiten mit regionalen Lieferanten zusammen.</div>
-<div class="card tile">Unsere Karte ist bewusst kompakt für beste Qualität.</div>
+  const t = i18n[state.lang].about;
+  document.getElementById('app').innerHTML = `
+<h2>${t.title}</h2>
+${t.lines.map(line => `<div class="card tile">${line}</div>`).join('')}
 `;
 }

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,6 +1,13 @@
 function renderContact(){
-document.getElementById('app').innerHTML = `
-<h2>Kontakt</h2>
-<div class="card tile">Moselweinstraße 14B, 56821 Ellenz-Poltersdorf<br>Telefon: 02671 2411502<br>E-Mail: hello@goncochicken.de</div>
+  const t = i18n[state.lang].contact;
+  document.getElementById('app').innerHTML = `
+<h2>${t.title}</h2>
+<div class="card tile">${t.info}</div>
+<form class="card tile" action="https://formspree.io/f/xnnzyrka" method="POST">
+  <label>${t.form.name}<br><input type="text" name="name" required></label>
+  <label>${t.form.email}<br><input type="email" name="_replyto" required></label>
+  <label>${t.form.message}<br><textarea name="message" required></textarea></label>
+  <button class="btn primary" type="submit">${t.form.send}</button>
+</form>
 `;
 }

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,23 +1,23 @@
 function renderHome(){
-document.getElementById('app').innerHTML = `
+  const t = i18n[state.lang].home;
+  document.getElementById('app').innerHTML = `
 <section class="hero">
   <div class="card copy">
-    <div class="kicker">Ellenz-Poltersdorf • Mosel</div>
-    <h1>Knuspriges Hähnchen, <br/>frisch & saftig – jeden Tag</h1>
-    <p class="lead">Willkommen bei <strong>Gonco Chicken</strong>. Bei uns gibt’s gold-knuspriges Hähnchen,
-    hausgemachte Saucen und Beilagen, die wirklich satt machen. Perfekt zum Mitnehmen oder zum Genießen vor Ort.</p>
+    <div class="kicker">${t.kicker}</div>
+    <h1>${t.headline}</h1>
+    <p class="lead">${t.lead}</p>
     <div class="cta">
-      <a class="btn primary" href="#menu">Zum Menü</a>
-      <a class="btn" href="#about">Mehr über uns</a>
+      <a class="btn primary" href="#menu">${t.btnMenu}</a>
+      <a class="btn" href="#about">${t.btnAbout}</a>
     </div>
   </div>
   <div class="card media">
     <img class="plate" src="https://images.unsplash.com/photo-1544025162-d76694265947?q=80&w=1200&auto=format&fit=crop">
-    <div class="badges"><div class="badge">Täglich 11–21 Uhr</div><div class="badge">Frisch frittiert</div></div>
+    <div class="badges"><div class="badge">${t.badgeHours}</div><div class="badge">${t.badgeFresh}</div></div>
   </div>
 </section>
 
-<section class="card tile" style="margin-top:18px"><h3>So findest du uns</h3>
+<section class="card tile" style="margin-top:18px"><h3>${t.findUs}</h3>
 <iframe class="map" loading="lazy" src="https://www.google.com/maps?q=Moselweinstra%C3%9Fe%2014B%2C%2056821%20Ellenz-Poltersdorf&output=embed"></iframe>
 </section>
 `;

--- a/pages/impressum.js
+++ b/pages/impressum.js
@@ -1,11 +1,12 @@
 function renderImpressum(){
-document.getElementById('app').innerHTML = `
-<h2>Impressum</h2>
+  const t = i18n[state.lang].impressum;
+  document.getElementById('app').innerHTML = `
+<h2>${t.title}</h2>
 <div class="card tile">
   Gonco Chicken – Moselweinstraße 14B, 56821 Ellenz-Poltersdorf
 </div>
 
-<h2>Datenschutzerklärung</h2>
+<h2>${t.dataTitle}</h2>
 <div class="card tile" style="white-space:pre-wrap">
 Wir freuen uns über Ihr Interesse an unserer Homepage und unserem Unternehmen. Für externe Links zu fremden Inhalten können wir dabei trotz sorgfältiger inhaltlicher Kontrolle keine Haftung übernehmen. Der Schutz Ihrer personenbezogenen Daten bei der Erhebung, Verarbeitung und Nutzung anlässlich Ihres Besuchs auf unserer Homepage ist uns ein wichtiges Anliegen. Ihre Daten werden im Rahmen der gesetzlichen Vorschriften geschützt. Nachfolgend finden Sie Informationen, welche Daten während Ihres Besuchs auf der Homepage erfasst und wie diese genutzt werden:
 

--- a/pages/menu.js
+++ b/pages/menu.js
@@ -1,10 +1,9 @@
 function renderMenu(){
-document.getElementById('app').innerHTML = `
-<h2>Menü</h2>
+  const t = i18n[state.lang].menu;
+  document.getElementById('app').innerHTML = `
+<h2>${t.title}</h2>
 <div class="grid">
-  <div class="card tile"><h3>Classic Fried Chicken</h3><p class="muted">Knuspriges Hähnchen – 9,50 €</p></div>
-  <div class="card tile"><h3>Spicy Wings (8 Stk.)</h3><p class="muted">Feurig und knusprig – 8,90 €</p></div>
-  <div class="card tile"><h3>Chicken Burger</h3><p class="muted">Mit Salat & Sauce – 10,50 €</p></div>
+  ${t.items.map(item => `<div class="card tile"><h3>${item.name}</h3><p class="muted">${item.desc}</p></div>`).join('')}
 </div>
 `;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,36 @@
-:root{
-  --bg:#0b0b0b; --card:#151515; --text:#f6f6f6; --muted:#bdbdbd; --accent:#ffbf37; --accent-2:#ff6a00;
-  --radius:16px; --shadow:0 10px 25px rgba(0,0,0,.25);
+:root {
+  --bg:#0b0b0b;
+  --card:#151515;
+  --text:#f6f6f6;
+  --muted:#bdbdbd;
+  --accent:#ffbf37;
+  --accent-2:#ff6a00;
+  --radius:16px;
+  --shadow:0 10px 25px rgba(0,0,0,.25);
 }
+
 *{box-sizing:border-box}
-html,body{margin:0;padding:0;background:linear-gradient(180deg,#0a0a0a,#111),var(--bg);color:var(--text);
-font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;display:flex;flex-direction:column;min-height:100vh}
+html,body{
+  margin:0;
+  padding:0;
+  background:linear-gradient(180deg,#0a0a0a,#111),var(--bg);
+  color:var(--text);
+  font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  display:flex;flex-direction:column;min-height:100vh;
+}
 a{color:inherit;text-decoration:none}
+body.light{
+  --bg:#f6f6f6;
+  --card:#ffffff;
+  --text:#0b0b0b;
+  --muted:#555;
+  background:linear-gradient(180deg,#ffffff,#f6f6f6),var(--bg);
+}
+body.light header{background:rgba(255,255,255,.85);border-bottom:1px solid #e0e0e0}
+body.light .btn{background:#fafafa;border:1px solid #ddd}
+body.light .btn:hover{border-color:#ccc}
+body.light .card{background:linear-gradient(180deg,#ffffff,#f7f7f7);border:1px solid #e0e0e0}
+body.light footer{border-top:1px solid #e0e0e0}
 main{flex:1}
 .container{max-width:1120px;margin:0 auto;padding:20px}
 header{position:sticky;top:0;background:rgba(10,10,10,.85);backdrop-filter:saturate(140%) blur(10px);z-index:20;border-bottom:1px solid #222}
@@ -30,6 +55,7 @@ h1{font-size:clamp(2rem,5vw,3.2rem);line-height:1.05;margin:10px 0 14px}
 .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
 .tile{padding:18px}
 .tile h3{margin:0 0 6px}
+.tile form{display:flex;flex-direction:column;gap:10px}
 .muted{color:var(--muted)}
 .open-hours{color:var(--accent);font-weight:600}
 .hours{display:grid;grid-template-columns:1fr auto;gap:6px;font-variant-numeric:tabular-nums}
@@ -52,3 +78,7 @@ footer{border-top:1px solid #1f1f1f}
 .popup-content{position:relative;background:var(--card);padding:24px;border-radius:var(--radius);box-shadow:var(--shadow);text-align:center}
 .popup.show .popup-content{animation:pop .4s ease}
 @keyframes pop{from{transform:scale(.85);opacity:0}to{transform:scale(1);opacity:1}}
+form label{display:block;margin-bottom:10px}
+input,textarea{width:100%;padding:8px;border-radius:8px;border:1px solid #2a2a2a;background:#121212;color:var(--text);font:inherit}
+textarea{min-height:100px}
+body.light input,body.light textarea{background:#fff;border:1px solid #ccc;color:#000}


### PR DESCRIPTION
## Summary
- Remove hours from header and add EN/DE and dark/light toggle buttons
- Introduce Formspree-powered contact form
- Support light theme, translations, and language/theme persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36fabf4b483218b076300c1ab65ab