### PR TITLE
Add DSGVO-compliant cookie consent modal

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -4,5 +4,6 @@ function renderFooter(){
     <div>© ${new Date().getFullYear()} Gonco Chicken • Moselweinstraße 14B, 56821 Ellenz-Poltersdorf</div>
     <div class="muted">${i18n[state.lang].footer.allergens}</div>
     <a class="btn" href="#impressum">${i18n[state.lang].footer.impressum}</a>
+    <button id="cookie-settings-btn" class="btn cookie-btn" type="button">Cookie-Einstellungen</button>
   </div>`;
 }

--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Gonco Chicken – Knuspriges Hähnchen in Ellenz-Poltersdorf</title>
 <link rel="stylesheet" href="styles.css">
+<style>
+.consent-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1000;}
+.consent-overlay.hidden{display:none;}
+.consent-modal{background:#fff;color:#000;padding:1rem 1.5rem;border-radius:6px;max-width:500px;width:90%;max-height:90vh;overflow:auto;box-shadow:0 2px 8px rgba(0,0,0,.3);}
+.consent-text{max-height:150px;overflow-y:auto;margin-bottom:1rem;}
+.consent-settings{margin-bottom:1rem;}
+.consent-settings label{display:block;margin-bottom:.5rem;}
+.consent-buttons{display:flex;flex-direction:column;gap:.5rem;}
+@media(min-width:480px){.consent-buttons{flex-direction:row;}}
+.consent-buttons button{flex:1;padding:.5rem;cursor:pointer;}
+.consent-buttons button:focus{outline:2px solid #000;outline-offset:2px;}
+footer .cookie-btn{margin-left:1rem;}
+</style>
 </head>
 <body>
 <header id="site-header"></header>
@@ -37,7 +50,7 @@ const i18n = {
       badgeHours: 'Täglich 11–21 Uhr',
       badgeFresh: 'Frisch frittiert',
       findUs: 'So findest du uns',
-      popup: 'Willkommen bei Gonco Chicken!'
+      
     },
     menu: {
       title: 'Menü',
@@ -77,7 +90,7 @@ const i18n = {
       badgeHours: 'Daily 11am–9pm',
       badgeFresh: 'Freshly fried',
       findUs: 'Find us',
-      popup: 'Welcome to Gonco Chicken!'
+
     },
     menu: {
       title: 'Menu',
@@ -159,12 +172,145 @@ window.addEventListener('load', () => {
   updateLang();
   initToggles();
   router();
-  const popup = document.createElement('div');
-  popup.className = 'popup';
-  popup.innerHTML = `<div class="popup-content"><p>${i18n[state.lang].home.popup}</p><button class="btn close-popup">OK</button></div>`;
-  document.body.appendChild(popup);
-  setTimeout(() => popup.classList.add('show'), 500);
-  popup.querySelector('.close-popup').addEventListener('click', () => popup.remove());
+});
+</script>
+
+<div id="consent-overlay" class="consent-overlay hidden">
+  <div id="consent-modal" class="consent-modal" role="dialog" aria-modal="true" aria-labelledby="consent-title" aria-describedby="consent-desc">
+    <h2 id="consent-title">Datenschutz-Einstellungen</h2>
+    <div id="consent-desc" class="consent-text">
+      <p>Wir verwenden Cookies, um unsere Website und unseren Service zu optimieren. Weitere Informationen finden Sie in unserer <a href="/datenschutz">Datenschutzerklärung</a> und <a href="/cookie-policy">Cookie-Richtlinie</a>.</p>
+    </div>
+    <div id="consent-settings" class="consent-settings" hidden>
+      <label><input type="checkbox" id="toggle-analytics"> Analytics</label>
+      <label><input type="checkbox" id="toggle-marketing"> Marketing</label>
+      <label><input type="checkbox" id="toggle-personalization"> Personalisierung</label>
+    </div>
+    <div class="consent-buttons">
+      <button id="btn-accept-all">AKTIVIEREN</button>
+      <button id="btn-necessary">NUR NOTWENDIGE TECHNOLOGIEN</button>
+      <button id="btn-customize">EINSTELLUNGEN ÄNDERN</button>
+    </div>
+  </div>
+</div>
+
+<script>
+const CONSENT_KEY = 'cookie-consent';
+const consentQueue = {};
+
+function getConsent(){
+  const raw = localStorage.getItem(CONSENT_KEY);
+  return raw ? JSON.parse(raw) : null;
+}
+
+function saveConsent(consent){
+  consent.timestamp = new Date().toISOString();
+  localStorage.setItem(CONSENT_KEY, JSON.stringify(consent));
+  window.dispatchEvent(new CustomEvent('consentchange',{detail:consent}));
+  Object.keys(consentQueue).forEach(p=>{
+    if(consent[p]) (consentQueue[p]||[]).forEach(fn=>fn());
+    consentQueue[p]=[];
+  });
+}
+
+function runWithConsent(purpose, fn){
+  const c = getConsent();
+  if(c && c[purpose]) fn();
+  else {
+    consentQueue[purpose] = consentQueue[purpose] || [];
+    consentQueue[purpose].push(fn);
+  }
+}
+
+function initConsent(){
+  const overlay = document.getElementById('consent-overlay');
+  const settingsDiv = document.getElementById('consent-settings');
+  const btnAll = document.getElementById('btn-accept-all');
+  const btnNec = document.getElementById('btn-necessary');
+  const btnCustom = document.getElementById('btn-customize');
+  const chkAnalytics = document.getElementById('toggle-analytics');
+  const chkMarketing = document.getElementById('toggle-marketing');
+  const chkPersonal = document.getElementById('toggle-personalization');
+
+  let inSettings = false;
+
+  function show(){
+    overlay.classList.remove('hidden');
+    inSettings = false;
+    settingsDiv.hidden = true;
+    btnCustom.textContent = 'EINSTELLUNGEN ÄNDERN';
+    trapFocus();
+    document.addEventListener('keydown', handleKeys);
+  }
+
+  function hide(){
+    overlay.classList.add('hidden');
+    document.removeEventListener('keydown', handleKeys);
+  }
+
+  function handleKeys(e){
+    if(e.key === 'Escape') hide();
+    if(e.key === 'Tab'){
+      const focusable = overlay.querySelectorAll('button, [href], input');
+      const first = focusable[0];
+      const last = focusable[focusable.length-1];
+      if(e.shiftKey && document.activeElement === first){
+        e.preventDefault();
+        last.focus();
+      }else if(!e.shiftKey && document.activeElement === last){
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  function trapFocus(){
+    const focusable = overlay.querySelectorAll('button, [href], input');
+    if(focusable.length) focusable[0].focus();
+  }
+
+  btnAll.addEventListener('click', ()=>{
+    saveConsent({necessary:true, analytics:true, marketing:true, personalization:true});
+    hide();
+  });
+  btnNec.addEventListener('click', ()=>{
+    saveConsent({necessary:true, analytics:false, marketing:false, personalization:false});
+    hide();
+  });
+  btnCustom.addEventListener('click', ()=>{
+    if(!inSettings){
+      settingsDiv.hidden = false;
+      btnCustom.textContent = 'SPEICHERN';
+      chkAnalytics.focus();
+      inSettings = true;
+    } else {
+      saveConsent({
+        necessary:true,
+        analytics:chkAnalytics.checked,
+        marketing:chkMarketing.checked,
+        personalization:chkPersonal.checked
+      });
+      hide();
+      inSettings = false;
+      btnCustom.textContent = 'EINSTELLUNGEN ÄNDERN';
+      settingsDiv.hidden = true;
+    }
+  });
+
+  const existing = getConsent();
+  if(!existing) show();
+
+  const footerBtn = document.getElementById('cookie-settings-btn');
+  if(footerBtn) footerBtn.addEventListener('click', show);
+}
+
+initConsent();
+
+runWithConsent('analytics', () => {
+  const s = document.createElement('script');
+  s.src = 'https://example.com/analytics.js';
+  s.async = true;
+  document.head.appendChild(s);
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add accessible cookie consent modal with scrollable policy text
- persist consent in localStorage and expose runWithConsent helper
- allow reopening via footer button and dispatch consentchange events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b47aa5483219b54757e9f9357aa