### PR TITLE
Improve mobile layout and theme-aware cookie dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,16 @@
 <link rel="stylesheet" href="styles.css">
 <style>
 .consent-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1000;}
+body.light .consent-overlay{background:rgba(0,0,0,.3);}
 .consent-overlay.hidden{display:none;}
-.consent-modal{background:#fff;color:#000;padding:1rem 1.5rem;border-radius:6px;max-width:500px;width:90%;max-height:90vh;overflow:auto;box-shadow:0 2px 8px rgba(0,0,0,.3);}
+.consent-modal{background:var(--card);color:var(--text);padding:1rem 1.5rem;border-radius:var(--radius);max-width:500px;width:90%;max-height:90vh;overflow:auto;box-shadow:var(--shadow);border:1px solid var(--border);}
 .consent-text{max-height:150px;overflow-y:auto;margin-bottom:1rem;}
 .consent-settings{margin-bottom:1rem;}
-.consent-settings label{display:block;margin-bottom:.5rem;}
+.consent-settings label{display:flex;align-items:center;gap:.5rem;margin-bottom:.5rem;}
 .consent-buttons{display:flex;flex-direction:column;gap:.5rem;}
 @media(min-width:480px){.consent-buttons{flex-direction:row;}}
-.consent-buttons button{flex:1;padding:.5rem;cursor:pointer;}
-.consent-buttons button:focus{outline:2px solid #000;outline-offset:2px;}
+.consent-buttons .btn{flex:1;padding:.5rem;}
+.consent-buttons .btn:focus{outline:2px solid var(--text);outline-offset:2px;}
 footer .cookie-btn{margin-left:1rem;}
 </style>
 </head>
@@ -187,9 +188,9 @@ window.addEventListener('load', () => {
       <label><input type="checkbox" id="toggle-personalization"> Personalisierung</label>
     </div>
     <div class="consent-buttons">
-      <button id="btn-accept-all">AKTIVIEREN</button>
-      <button id="btn-necessary">NUR NOTWENDIGE TECHNOLOGIEN</button>
-      <button id="btn-customize">EINSTELLUNGEN ÄNDERN</button>
+      <button id="btn-accept-all" class="btn primary">AKTIVIEREN</button>
+      <button id="btn-necessary" class="btn">NUR NOTWENDIGE TECHNOLOGIEN</button>
+      <button id="btn-customize" class="btn">EINSTELLUNGEN ÄNDERN</button>
     </div>
   </div>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,7 @@
   --accent-2:#ff6a00;
   --radius:16px;
   --shadow:0 10px 25px rgba(0,0,0,.25);
+  --border:#1f1f1f;
 }
 
 *{box-sizing:border-box}
@@ -24,16 +25,16 @@ body.light{
   --card:#ffffff;
   --text:#0b0b0b;
   --muted:#555;
+  --border:#e0e0e0;
   background:linear-gradient(180deg,#ffffff,#f6f6f6),var(--bg);
 }
-body.light header{background:rgba(255,255,255,.85);border-bottom:1px solid #e0e0e0}
+body.light header{background:rgba(255,255,255,.85)}
 body.light .btn{background:#fafafa;border:1px solid #ddd}
 body.light .btn:hover{border-color:#ccc}
-body.light .card{background:linear-gradient(180deg,#ffffff,#f7f7f7);border:1px solid #e0e0e0}
-body.light footer{border-top:1px solid #e0e0e0}
+body.light .card{background:linear-gradient(180deg,#ffffff,#f7f7f7)}
 main{flex:1}
 .container{max-width:1120px;margin:0 auto;padding:20px}
-header{position:sticky;top:0;background:rgba(10,10,10,.85);backdrop-filter:saturate(140%) blur(10px);z-index:20;border-bottom:1px solid #222}
+header{position:sticky;top:0;background:rgba(10,10,10,.85);backdrop-filter:saturate(140%) blur(10px);z-index:20;border-bottom:1px solid var(--border)}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:16px}
 .brand{display:flex;align-items:center;gap:10px;font-weight:800;letter-spacing:.3px}
 .logo{width:36px;height:36px;border-radius:50%;background:conic-gradient(from 220deg,var(--accent),var(--accent-2));box-shadow:0 0 0 2px #222}
@@ -42,16 +43,16 @@ header{position:sticky;top:0;background:rgba(10,10,10,.85);backdrop-filter:satur
 .btn:hover{transform:translateY(-1px);border-color:#3a3a3a}
 .btn.primary{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#1a1200;border:none;box-shadow:var(--shadow)}
 .hero{display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:center;padding:48px 0}
-.card{background:linear-gradient(180deg,#131313,#101010);border:1px solid #1f1f1f;border-radius:var(--radius);box-shadow:var(--shadow);animation:fadeInUp .4s ease both}
+.card{background:linear-gradient(180deg,#131313,#101010);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);animation:fadeInUp .4s ease both}
 .hero .copy{padding:28px}
 .kicker{color:var(--accent);font-weight:700;letter-spacing:.12em;text-transform:uppercase;font-size:.9rem}
 h1{font-size:clamp(2rem,5vw,3.2rem);line-height:1.05;margin:10px 0 14px}
 .lead{color:var(--muted);font-size:1.05rem}
 .cta{margin-top:18px;display:flex;gap:10px;flex-wrap:wrap}
 .hero .media{position:relative;overflow:hidden}
-.plate{aspect-ratio:4/3;width:100%;border-radius:var(--radius);display:block;border:1px solid #1f1f1f}
+.plate{aspect-ratio:4/3;width:100%;border-radius:var(--radius);display:block;border:1px solid var(--border)}
 .badges{position:absolute;inset:auto 12px 12px auto;display:flex;flex-direction:column;gap:8px}
-.badge{padding:8px 12px;border-radius:12px;background:#0f0f0f;border:1px solid #222;font-size:.9rem}
+.badge{padding:8px 12px;border-radius:12px;background:var(--card);border:1px solid var(--border);color:var(--text);font-size:.9rem}
 .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
 .tile{padding:18px}
 .tile h3{margin:0 0 6px}
@@ -59,7 +60,7 @@ h1{font-size:clamp(2rem,5vw,3.2rem);line-height:1.05;margin:10px 0 14px}
 .muted{color:var(--muted)}
 .open-hours{color:var(--accent);font-weight:600}
 .hours{display:grid;grid-template-columns:1fr auto;gap:6px;font-variant-numeric:tabular-nums}
-footer{border-top:1px solid #1f1f1f}
+footer{border-top:1px solid var(--border)}
 .foot{display:grid;gap:8px;padding:24px 0;color:#cfcfcf}
 .map{border:0;width:100%;height:300px;border-radius:12px;filter:grayscale(.1) contrast(1.05)}
 .mobile{display:none}
@@ -69,7 +70,13 @@ footer{border-top:1px solid #1f1f1f}
   .desktop{display:none}
   .mobile{display:inline-flex}
   .navlinks{display:none}
-  .nav.open .navlinks{display:flex;position:absolute;left:0;right:0;top:64px;padding:12px;background:#0f0f0fe6;backdrop-filter:blur(8px);border-bottom:1px solid #222}
+  .nav.open .navlinks{display:flex;position:absolute;left:0;right:0;top:64px;padding:12px;background:#0f0f0fe6;backdrop-filter:blur(8px);border-bottom:1px solid var(--border)}
+}
+.cta .btn{text-align:center}
+@media (max-width:600px){
+  .cta{flex-direction:column}
+  .cta .btn{width:100%}
+  .hero{padding:32px 0}
 }
 .active{outline:2px solid #2b2b2b}
 @keyframes fadeInUp{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
@@ -79,6 +86,6 @@ footer{border-top:1px solid #1f1f1f}
 .popup.show .popup-content{animation:pop .4s ease}
 @keyframes pop{from{transform:scale(.85);opacity:0}to{transform:scale(1);opacity:1}}
 form label{display:block;margin-bottom:10px}
-input,textarea{width:100%;padding:8px;border-radius:8px;border:1px solid #2a2a2a;background:#121212;color:var(--text);font:inherit}
+input[type="text"],input[type="email"],textarea{width:100%;padding:8px;border-radius:8px;border:1px solid #2a2a2a;background:#121212;color:var(--text);font:inherit}
 textarea{min-height:100px}
-body.light input,body.light textarea{background:#fff;border:1px solid #ccc;color:#000}
+body.light input[type="text"],body.light input[type="email"],body.light textarea{background:#fff;border:1px solid #ccc;color:#000}


### PR DESCRIPTION
## Summary
- Add responsive tweaks for small screens and CTA buttons
- Use theme variables so hero image badges adapt in light and dark mode
- Restyle cookie consent modal to match site theme and buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8838308248321b092e5a19b954503